### PR TITLE
Share flash data

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -51,6 +51,13 @@ class HandleInertiaRequests extends Middleware
                 'location' => $request->url(),
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
+            'flash' => function () {
+                return [
+                    'success' => session('success'),
+                    'error' => session('error'),
+                    'message' => session('message'),
+                ];
+            },
         ];
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -51,13 +51,11 @@ class HandleInertiaRequests extends Middleware
                 'location' => $request->url(),
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
-            'flash' => function () {
-                return [
-                    'success' => session('success'),
-                    'error' => session('error'),
-                    'message' => session('message'),
-                ];
-            },
+            'flash' => fn () => [
+                'success' => session('success'),
+                'error' => session('error'),
+                'message' => session('message'),
+            ],
         ];
     }
 }

--- a/resources/js/hooks/useFlash.ts
+++ b/resources/js/hooks/useFlash.ts
@@ -1,0 +1,7 @@
+import type { SharedData } from '@/types';
+import { usePage } from '@inertiajs/react';
+
+export function useFlash() {
+    const page = usePage<SharedData>();
+    return page.props.flash;
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -29,9 +29,9 @@ export interface SharedData {
     ziggy: Config & { location: string };
     sidebarOpen: boolean;
     flash: {
-        success: string | null;
-        error: string | null;
-        message: string | null;
+        success: unknown | null;
+        error: unknown | null;
+        message: unknown | null;
     };
     [key: string]: unknown;
 }

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -28,6 +28,11 @@ export interface SharedData {
     auth: Auth;
     ziggy: Config & { location: string };
     sidebarOpen: boolean;
+    flash: {
+        success: string | null;
+        error: string | null;
+        message: string | null;
+    };
     [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Add flash data (success, error, message) to Inertia shared props and update TypeScript definitions accordingly

New Features:
- Share Laravel session flash messages (success, error, message) via Inertia middleware

Enhancements:
- Extend SharedData TypeScript interface to include flash property